### PR TITLE
Use new path for snapserver fifo

### DIFF
--- a/ansible/librespot/files/librespot.service.j2
+++ b/ansible/librespot/files/librespot.service.j2
@@ -11,7 +11,7 @@ DynamicUser=no
 SupplementaryGroups=audio
 Restart=always
 RestartSec=10
-ExecStart=/root/.cargo/bin/librespot --name="{{ speaker_name }}" --cache=/root/librespot-cache --backend=pipe --device=/run/snapfifo --initial-volume=100
+ExecStart=/root/.cargo/bin/librespot --name="{{ speaker_name }}" --cache=/root/librespot-cache --backend=pipe --device=/run/snapserver/snapfifo --initial-volume=100
 
 [Install]
 WantedBy=multi-user.target

--- a/ansible/snapclient/playbook.yaml
+++ b/ansible/snapclient/playbook.yaml
@@ -9,18 +9,22 @@
       apt:
         name: alsa-utils
         state: present
+
     - name: Download snapclient .deb
       get_url:
         url: "https://github.com/badaix/snapcast/releases/download/v{{ version }}/snapclient_{{ version }}-1_arm64_bookworm.deb"
         dest: "/tmp/snapclient_{{ version }}.deb"
+
     - name: Install snapclient .deb
       apt:
         deb: "/tmp/snapclient_{{ version }}.deb"
         state: present
+
     - name: Copy snapclient config
       template:
         src: ./default/snapclient.j2
         dest: /etc/default/snapclient
+
     - name: Start snapclient
       systemd:
         name: snapclient

--- a/ansible/snapserver/files/snapserver.conf
+++ b/ansible/snapserver/files/snapserver.conf
@@ -165,7 +165,7 @@ port = 1705
 # alsa: alsa:///?name=<name>&device=<alsa device>[&send_silence=false][&idle_threshold=100][&silence_threshold_percent=0.0]
 # meta: meta:///<name of source#1>/<name of source#2>/.../<name of source#N>?name=<name>
 #source = pipe:///tmp/snapfifo?name=default
-source = pipe:///run/snapfifo?name=default
+source = pipe:///run/snapserver/snapfifo?name=default
 #source = spotify:///var/lib/snapserver/.cargo/bin/librespot?name=Spotify&devicename=testin2&cache_dir=/var/lib/snapserver/librespot-cache
 
 # Plugin directory, containing scripts, referred by "controlscript"

--- a/ansible/snapserver/playbook.yaml
+++ b/ansible/snapserver/playbook.yaml
@@ -11,10 +11,13 @@
         name: alsa-utils
         state: present
 
-    - name: Make snap pipe
-      command: mkfifo /run/snapfifo
-      args:
-        creates: /run/snapfifo
+    - name: Create /run/snapserver directory
+      file:
+        path: /run/snapserver
+        state: directory
+        owner: snapserver
+        group: snapserver
+        mode: '0755'
 
     - name: Download snapserver .deb
       get_url:


### PR DESCRIPTION
Rather than `/run/snapfifo`, put in `/run/snapserver/snapfifo`. This way I can give `snapserver:snapserver` permissions to `/run/snapserver` for it to be able to create the fifo itself. Previously I had been creating the fifo with `mkfifo`, but it got wiped out on restart. This way, snapserver can manage its own fifo like it's supposed to.