### PR TITLE
Remove snapclient config file

### DIFF
--- a/ansible/snapclient/default/snapclient.j2
+++ b/ansible/snapclient/default/snapclient.j2
@@ -1,6 +1,0 @@
-# Start the client, used only by the init.d script
-START_SNAPCLIENT=true
-# Additional command line options that will be passed to snapclient
-# note that user/group should be configured in the init.d script or the systemd unit file
-# For a list of available options, invoke "snapclient --help" 
-SNAPCLIENT_OPTS="--player=alsa -s{{ soundcard }} --host=192.168.1.94"


### PR DESCRIPTION
This isn't used anymore now that snapclient is installed by compiling from source.