### PR TITLE
Use ansible 1password integration

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,8 +1,1 @@
-export SAMBA_PASSWORD_BAZARR=$(op read "op://Infra/samba bazarr/password" --account=my.1password.com)
-export SAMBA_PASSWORD_CAROLYN=$(op read "op://CJ Shared/Carolyn file backup/password" --account=my.1password.com)
-export SAMBA_PASSWORD_JUTONZ=$(op read "op://Infra/samba jutonz/password" --account=my.1password.com)
-export SAMBA_PASSWORD_PLEX=$(op read "op://Infra/samba plex/password" --account=my.1password.com)
-export SAMBA_PASSWORD_QBT=$(op read "op://Infra/samba qbt/password" --account=my.1password.com)
-export SAMBA_PASSWORD_RADARR=$(op read "op://Infra/samba radarr/password" --account=my.1password.com)
-export SAMBA_PASSWORD_SONARR=$(op read "op://Infra/samba sonarr/password" --account=my.1password.com)
 export SOPS_AGE_KEY=$(op read "op://Infra/age encryption key/secret key" --account=my.1password.com)

--- a/ansible/samba/files/smb.conf.j2
+++ b/ansible/samba/files/smb.conf.j2
@@ -11,7 +11,7 @@
   vfs objects = full_audit
 
 [qbt]
-  path = /tank/data/rr
+  path = /tank/qbt
   valid users = qbt sonarr radarr plex bazarr
   force group = qbt_samba
   browsable = no

--- a/ansible/samba/playbook.yaml
+++ b/ansible/samba/playbook.yaml
@@ -25,27 +25,27 @@
         gid: 1601
     samba_users:
       - name: qbt
-        password: "{{ lookup('env', 'SAMBA_PASSWORD_QBT') }}"
+        password: "{{ lookup('community.general.onepassword', 'samba qbt', field='password', vault='Infra') }}"
         uid: 1400
         groups: ["qbt", "qbt_samba"]
       - name: sonarr
-        password: "{{ lookup('env', 'SAMBA_PASSWORD_SONARR') }}"
+        password: "{{ lookup('community.general.onepassword', 'samba sonarr', field='password', vault='Infra') }}"
         uid: 1401
         groups: ["sonarr", "qbt_samba"]
       - name: radarr
-        password: "{{ lookup('env', 'SAMBA_PASSWORD_RADARR') }}"
+        password: "{{ lookup('community.general.onepassword', 'samba radarr', field='password', vault='Infra') }}"
         uid: 1402
         groups: ["radarr", "qbt_samba"]
       - name: plex
-        password: "{{ lookup('env', 'SAMBA_PASSWORD_PLEX') }}"
+        password: "{{ lookup('community.general.onepassword', 'samba plex', field='password', vault='Infra') }}"
         uid: 1403
         groups: ["plex", "qbt_samba"]
       - name: bazarr
-        password: "{{ lookup('env', 'SAMBA_PASSWORD_BAZARR') }}"
+        password: "{{ lookup('community.general.onepassword', 'samba bazarr', field='password', vault='Infra') }}"
         uid: 1404
         groups: ["bazarr", "qbt_samba"]
       - name: carolyn
-        password: "{{ lookup('env', 'SAMBA_PASSWORD_CAROLYN') }}"
+        password: "{{ lookup('community.general.onepassword', 'Carolyn file backup', field='password', vault='CJ Shared') }}"
         uid: 1601
         groups: ["carolyn", "cj", "qbt_samba"]
   tasks:
@@ -96,7 +96,7 @@
         executable: /bin/bash
       changed_when: false
       vars:
-        password: "{{ lookup('env', 'SAMBA_PASSWORD_JUTONZ') }}"
+        password: "{{ lookup('community.general.onepassword', 'samba jutonz', field='password', vault='Infra') }}"
 
     # - name: Create qbt share directory
     #   ansible.builtin.file:


### PR DESCRIPTION
Rather than loading secrets via direnv, which makes changing directories pretty painful, let's pull the secrets at runtime using ansible's 1password integration.