### PR TITLE
Track backup success in prometheus

### DIFF
--- a/ansible/node_exporter/files/node_exporter.service.j2
+++ b/ansible/node_exporter/files/node_exporter.service.j2
@@ -8,7 +8,7 @@ User=root
 DynamicUser=no
 Restart=always
 RestartSec=10
-ExecStart=/usr/local/bin/node_exporter {{ command_line_args }}
+ExecStart=/usr/local/bin/node_exporter {{ command_line_args | join(' ') }}
 
 [Install]
 WantedBy=multi-user.target

--- a/ansible/node_exporter/hosts.yaml
+++ b/ansible/node_exporter/hosts.yaml
@@ -6,7 +6,7 @@ all:
       ansible_user: root
       arch: amd64
     littlebox:
-      ansible_host: littlebox.local
+      ansible_host: littlebox
       ansible_user: root
       arch: amd64
     ttv:

--- a/ansible/node_exporter/playbook.yaml
+++ b/ansible/node_exporter/playbook.yaml
@@ -31,7 +31,8 @@
         dest: /usr/lib/systemd/system/node_exporter.service
         mode: "0644"
       vars:
-        command_line_args: --web.listen-address=:9100
+        command_line_args:
+          - --web.listen-address=:9100
 
     - name: Enable and start service
       ansible.builtin.systemd:

--- a/ansible/restic/files/backup.sh.j2
+++ b/ansible/restic/files/backup.sh.j2
@@ -29,3 +29,9 @@ date
   --prune
 
 /usr/local/bin/restic snapshots
+
+cat <<EOF | curl --data-binary @- {{ pushgateway_url }}/metrics/job/docker_backup/instance/$(hostname)
+# HELP last_success_timestamp_seconds Unix time of the last successful run.
+# TYPE last_success_timestamp_seconds gauge
+last_success_timestamp_seconds $(date +%s)
+EOF

--- a/ansible/restic/playbook.yaml
+++ b/ansible/restic/playbook.yaml
@@ -7,6 +7,7 @@
     version: "0.18.1"
     backup_start_hour: 6
     backup_hour: "{{ backup_start_hour | int + (ansible_play_hosts.index(inventory_hostname) | int) }}"
+    pushgateway_url: http://192.168.1.94:9091
   tasks:
     - name: Install packages
       ansible.builtin.package:


### PR DESCRIPTION
When the backup script finishes, record success in prometheus. I can use this to monitor that the scripts are running.

For now I'm using pushgateway, but maybe some type of dead man's switch or log monitoring setup would be better in the long run. I'd like a way of seeing logs for other services too. 