### PR TITLE
Fix restic pruning policy

### DIFF
--- a/ansible/restic/files/backup.sh.j2
+++ b/ansible/restic/files/backup.sh.j2
@@ -22,10 +22,10 @@ date
 /usr/local/bin/restic \
   forget \
   --host={{hostname }} \
-  --keep-daily=1 \
-  --keep-weekly=1 \
-  --keep-monthly=1 \
-  --keep-yearly=1 \
+  --keep-within-daily=7d \
+  --keep-within-weekly=1m \
+  --keep-within-monthly=1y \
+  --keep-within-yearly=100y \
   --prune
 
 /usr/local/bin/restic check


### PR DESCRIPTION
Previously the policy said to keep 1 backup for each daily, weekly, monthly, and yearly. However this resulted in only 1 backup being retained, since the most recent backup satisfied all of those criteria.

Instead what I intended was to keep 1 backup for each day (up to a week), 1 backup for each week (up to a month), 1 backup for each month (up to a year), and 1 backup for each year (up to 100 years). This is the purpose of the `--keep-within-*` [policy flags], so here I switch to those.

[policy flags]: https://restic.readthedocs.io/en/latest/060_forget.html