### PR TITLE
Increase prometheus retention

### DIFF
--- a/monitoring/prometheus-deployment.yaml
+++ b/monitoring/prometheus-deployment.yaml
@@ -23,7 +23,7 @@ spec:
         io.kompose.service: prometheus
     spec:
       containers:
-        - image: prom/prometheus:v3.3.1
+        - image: prom/prometheus:v3.6.0
           name: prometheus
           args:
             # Defaults from Dockerfile CMD

--- a/monitoring/prometheus-deployment.yaml
+++ b/monitoring/prometheus-deployment.yaml
@@ -23,8 +23,17 @@ spec:
         io.kompose.service: prometheus
     spec:
       containers:
-        - image: prom/prometheus:v3.2.1
+        - image: prom/prometheus:v3.3.1
           name: prometheus
+          args:
+            # Defaults from Dockerfile CMD
+            # https://github.com/prometheus/prometheus/blob/main/Dockerfile
+            # NOTE: Make sure these stays in sync when upgrading.
+            - "--config.file=/etc/prometheus/prometheus.yml"
+            - "--storage.tsdb.path=/prometheus"
+            # Ones I added:
+            # Increase metric retention time from default 15 days
+            - "--storage.tsdb.retention.time=31d"
           ports:
             - containerPort: 9090
               protocol: TCP


### PR DESCRIPTION
Increase from the default of 15 days to 31 days. This will make it easier to see trends for metrics which change at a slower rate. I'm using about 650 mb for 15 days so I can expect to use about double that for 31 days, which is fine.

Also upgrade prometheus to the latest released version.