### PR TITLE
Add Longhorn ansible playbook to blacklist multipathd

### DIFF
--- a/ansible/longhorn/files/multipath.conf
+++ b/ansible/longhorn/files/multipath.conf
@@ -1,0 +1,7 @@
+defaults {
+    user_friendly_names yes
+}
+
+blacklist {
+    devnode "^sd[a-z0-9]+"
+}

--- a/ansible/longhorn/hosts.yaml
+++ b/ansible/longhorn/hosts.yaml
@@ -1,0 +1,12 @@
+---
+all:
+  hosts:
+    cary:
+      ansible_host: cary
+      ansible_user: root
+    littlebox:
+      ansible_host: littlebox
+      ansible_user: root
+    mini:
+      ansible_host: mini
+      ansible_user: root

--- a/ansible/longhorn/playbook.yaml
+++ b/ansible/longhorn/playbook.yaml
@@ -1,0 +1,20 @@
+---
+- name: Configure nodes for Longhorn
+  hosts: all
+  become: true
+  tasks:
+    - name: Blacklist Longhorn devices from multipathd
+      ansible.builtin.copy:
+        src: files/multipath.conf
+        dest: /etc/multipath.conf
+        owner: root
+        group: root
+        mode: "0644"
+      notify: Restart multipathd
+
+  handlers:
+    - name: Restart multipathd
+      ansible.builtin.systemd:
+        name: multipathd
+        state: restarted
+        daemon_reload: true

--- a/ansible/longhorn/update.sh
+++ b/ansible/longhorn/update.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+ansible-playbook -i ./hosts.yaml ./playbook.yaml


### PR DESCRIPTION
## Summary
- Adds a new `ansible/longhorn` playbook that configures `/etc/multipath.conf` on all k3s nodes to blacklist `sd*` devices from multipathd
- multipathd was claiming Longhorn block devices (`IET VIRTUAL-DISK`), causing `mount: already mounted or mount point busy` errors when pods tried to mount Longhorn volumes
- Resolves the issue described in longhorn/longhorn#12455

## Test plan
- [x] Ran playbook on all three nodes (cary, littlebox, mini)
- [x] Confirmed prometheus pod successfully mounted its 25Gi expanded volume after the fix