### PR TITLE
Reduce defalt volumes for buckets

### DIFF
--- a/seaweedfs/kustomization.yaml
+++ b/seaweedfs/kustomization.yaml
@@ -4,6 +4,7 @@ namespace: seaweedfs
 resources:
 - ./namespace.yaml
 - ./master-service.yaml
+- ./master-config-map.yaml
 - ./master-deployment.yaml
 - ./volume-service.yaml
 - ./volume-stateful-set.yaml

--- a/seaweedfs/master-config-map.yaml
+++ b/seaweedfs/master-config-map.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: master-config
+data:
+  master.toml: |
+    [master.volume_growth]
+    copy_1 = 1
+    copy_2 = 1
+    copy_3 = 1
+    copy_other = 1

--- a/seaweedfs/master-deployment.yaml
+++ b/seaweedfs/master-deployment.yaml
@@ -34,4 +34,11 @@ spec:
               protocol: TCP
             - containerPort: 19333
               protocol: TCP
+          volumeMounts:
+            - name: config
+              mountPath: /etc/seaweedfs
+      volumes:
+        - name: config
+          configMap:
+            name: master-config
       restartPolicy: Always


### PR DESCRIPTION
By default seaweed creates 7 volumes for a bucket. Here I reduce that to
1.
