### PR TITLE
Add volume-large statefulset for seaweed

### DIFF
--- a/seaweedfs/kustomization.yaml
+++ b/seaweedfs/kustomization.yaml
@@ -8,6 +8,7 @@ resources:
 - ./master-deployment.yaml
 - ./volume-service.yaml
 - ./volume-stateful-set.yaml
+- ./volume-large-stateful-set.yaml
 - ./filer-config-map.yaml
 - ./filer-data-pvc.yaml
 - ./filer-service.yaml

--- a/seaweedfs/volume-large-stateful-set.yaml
+++ b/seaweedfs/volume-large-stateful-set.yaml
@@ -1,10 +1,10 @@
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: volume
+  name: volume-large
 spec:
   serviceName: volume
-  replicas: 3
+  replicas: 1
   selector:
     matchLabels:
       app: volume
@@ -37,4 +37,4 @@ spec:
         storageClassName: longhorn
         resources:
           requests:
-            storage: 50Gi
+            storage: 110Gi


### PR DESCRIPTION
Bumps existing volume sts to 3 replicas and introduces a parallel volume-large statefulset with 110Gi PVCs (fits 10 SeaweedFS volumes each, vs 4 in the 50Gi pods).