### PR TITLE
Scale down seaweed volume statefulset to 2 replicas

### DIFF
--- a/seaweedfs/volume-stateful-set.yaml
+++ b/seaweedfs/volume-stateful-set.yaml
@@ -4,7 +4,7 @@ metadata:
   name: volume
 spec:
   serviceName: volume
-  replicas: 3
+  replicas: 2
   selector:
     matchLabels:
       app: volume


### PR DESCRIPTION
volume-2 has been drained onto volume-large-2; reducing replicas to
remove the empty pod so the data-volume-2 PVC can be reclaimed.
