### PR TITLE
Upgrade tempo to 3.0.0

### DIFF
--- a/monitoring/tempo-config-configmap.yaml
+++ b/monitoring/tempo-config-configmap.yaml
@@ -8,8 +8,6 @@ metadata:
   name: tempo-config
 data:
   tempo-config.yaml: |
-    auth_enabled: false
-
     server:
       http_listen_port: 3200
 
@@ -22,16 +20,13 @@ data:
             http:
               endpoint: "0.0.0.0:4418"
 
-    ingester:
-      trace_idle_period: 10s
-      max_block_duration: 5m
-
-    compactor:
-      compaction:
-        block_retention: 1h
-
     storage:
       trace:
         backend: local
+        wal:
+          path: /tmp/tempo/wal
         local:
-          path: /tmp/tempo
+          path: /tmp/tempo/blocks
+
+    usage_report:
+      reporting_enabled: false

--- a/monitoring/tempo-data-lh-pvc.yaml
+++ b/monitoring/tempo-data-lh-pvc.yaml
@@ -8,4 +8,4 @@ spec:
   storageClassName: longhorn
   resources:
     requests:
-      storage: 1Gi
+      storage: 10Gi

--- a/monitoring/tempo-deployment.yaml
+++ b/monitoring/tempo-deployment.yaml
@@ -22,6 +22,8 @@ spec:
       labels:
         io.kompose.service: tempo
     spec:
+      securityContext:
+        fsGroup: 10001
       containers:
         # https://github.com/grafana/tempo/releases
         - image: grafana/tempo:3.0.0

--- a/monitoring/tempo-deployment.yaml
+++ b/monitoring/tempo-deployment.yaml
@@ -24,7 +24,7 @@ spec:
     spec:
       containers:
         # https://github.com/grafana/tempo/releases
-        - image: grafana/tempo:2.10.5
+        - image: grafana/tempo:3.0.0
           name: tempo
           args:
             - -config.file=/etc/tempo-config.yaml


### PR DESCRIPTION
## Summary
- Bump grafana/tempo image 2.10.5 -> 3.0.0
- Drop ingester:/compactor: config blocks (eliminated in 3.0), split storage into wal/blocks subdirs, disable usage_report
- Resize tempo PVC 1Gi -> 10Gi for the new ~14-day default retention

## Test plan
- [ ] Operator: scale tempo to 0, delete tempo-data-lh PVC, apply manifests
- [ ] Verify pod is Running 1/1 with no 'unknown field' errors in logs
- [ ] Send a test trace via otel-collector -> trace appears in Grafana's Tempo datasource