### PR TITLE
seaweedfs: advertise stable per-pod DNS via -ip so filer cache survives pod restarts

### DIFF
--- a/seaweedfs/volume-large-stateful-set.yaml
+++ b/seaweedfs/volume-large-stateful-set.yaml
@@ -16,12 +16,18 @@ spec:
       containers:
         - image: chrislusf/seaweedfs:4.33
           name: volume
+          env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
           args:
             - volume
             - "-mserver=master:9333"
             - "-dir=/data"
             - "-max=0"
             - "-port=8080"
+            - "-publicUrl=$(POD_NAME).volume:8080"
           ports:
             - containerPort: 8080
             - containerPort: 18080

--- a/seaweedfs/volume-large-stateful-set.yaml
+++ b/seaweedfs/volume-large-stateful-set.yaml
@@ -27,7 +27,8 @@ spec:
             - "-dir=/data"
             - "-max=0"
             - "-port=8080"
-            - "-publicUrl=$(POD_NAME).volume:8080"
+            - "-ip=$(POD_NAME).volume"
+            - "-ip.bind=0.0.0.0"
           ports:
             - containerPort: 8080
             - containerPort: 18080


### PR DESCRIPTION
## Background

On 2026-06-13 the SeaweedFS filer stranded itself on a dead pod IP after `volume-large-1` was rescheduled to a different node. The Rails app started returning truncated images for ~9h until the filer was bounced. Root cause: the filer caches volume locations from the master and only refreshes via gRPC push, which can be dropped silently — leaving the filer dialing a pod that no longer exists.

## What this PR does

`volume-large` StatefulSet now passes:

```
-ip=$(POD_NAME).volume
-ip.bind=0.0.0.0
```

`-ip` sets what the volume server advertises to the master, which lands in the `url` field that the filer reads when fetching chunks. With `-ip=volume-large-N.volume`, the master records the DNS name. The filer's HTTP requests go through CoreDNS each time, which resolves to the pod's _current_ IP via the headless `volume` Service. Pod IP changes are transparent.

`-ip.bind=0.0.0.0` is required because the pod's headless-service DNS record only exists once the pod is Ready, but the volume server starts before Ready. Letting `-ip` drive both advertise and bind would race the service controller at startup; binding all interfaces sidesteps that.

`POD_NAME` is sourced from the downward API.

## What I tried first that didn't work

Two commits on this branch:
1. ~~`-publicUrl=$(POD_NAME).volume:8080`~~ — pushed first because external documentation suggested `publicUrl` was the field clients read. Verified live: the filer's chunk-fetch path (`http_global_client_util.go`) reads `url`, NOT `publicUrl`. With `-publicUrl` alone, the master kept reporting `url=<pod-IP>` and the filer kept caching IPs. Documented for posterity; the second commit overrides it.
2. `-ip=$(POD_NAME).volume` + `-ip.bind=0.0.0.0` — the actual fix. With this, master reports `url=volume-large-N.volume:8080`. Verified working below.

## Test plan

- [x] All 5 pods rolled cleanly. Each pod's `/proc/1/cmdline` shows resolved `-ip=volume-large-<N>.volume`.
- [x] All 32 volumes report `url=volume-large-<N>.volume:8080` from master `/dir/lookup` (0 IP-based urls, distribution 6/8/5/6/7 across pods).
- [x] Image load test: https://app.jutonz.com/plants/14 renders the full 4284×5712 image.
- [x] **Force-restart proof:** deleted `volume-large-1`, new pod came up at a different IP (`10.42.0.91 → 10.42.0.92`), filer was NOT bounced, image still rendered cleanly on subsequent cache-busted page load.

## Caveats

- Required a one-time filer bounce during rollout to clear its pre-fix IP-based cache. Future volume-pod restarts no longer require a filer bounce.
- Existing in-cluster CoreDNS caching means there's a few-second window during a volume pod restart where DNS may still return the old IP; the filer's existing retry-with-backoff swallows it.
- Out of scope (separate ticket if we want it): a filer livenessProbe that catches the underlying SeaweedFS gRPC-push reliability issue.