### PR TITLE
Add node_reboot_required metric

### DIFF
--- a/ansible/node_exporter/files/prom-apt-upgradable.timer
+++ b/ansible/node_exporter/files/prom-apt-upgradable.timer
@@ -3,6 +3,7 @@ Description=Push apt upgradable metrics to prometheus
 
 [Timer]
 OnCalendar=*-*-* *:30:00
+OnBootSec=2min
 Persistent=true
 Unit=prom-apt-upgradable.service
 

--- a/ansible/node_exporter/files/prom_apt_upgradable_push.sh.j2
+++ b/ansible/node_exporter/files/prom_apt_upgradable_push.sh.j2
@@ -5,10 +5,18 @@ export DEBIAN_FRONTEND=noninteractive
 
 UPGRADABLE=$(apt-get -s dist-upgrade | awk '/^Inst / { count++ } END { print count+0 }')
 
+REBOOT_REQUIRED=0
+if [ -f /var/run/reboot-required ]; then
+  REBOOT_REQUIRED=1
+fi
+
 METRICS=$(cat <<EOF_METRICS
 # HELP apt_upgradable_packages Number of apt packages that can be upgraded
 # TYPE apt_upgradable_packages gauge
 apt_upgradable_packages ${UPGRADABLE}
+# HELP node_reboot_required Whether the node requires a reboot (/var/run/reboot-required exists)
+# TYPE node_reboot_required gauge
+node_reboot_required ${REBOOT_REQUIRED}
 EOF_METRICS
 )
 


### PR DESCRIPTION
## Summary
- Push a `node_reboot_required` gauge (1 if `/var/run/reboot-required` exists, else 0) from the existing `prom_apt_upgradable_push.sh` script, under the existing `job="apt_upgradable"` grouping key on the pushgateway.
- Add `OnBootSec=2min` to `prom-apt-upgradable.timer` so the metric clears shortly after a reboot instead of waiting up to an hour for the next `:30` tick.

## Verification
Deployed via `ansible/node_exporter/playbook.yaml` to all five hosts (cary first, then mini/littlebox/ttv/speaker; speaker needed one retry after a transient unreachable).

Both metric states confirmed on the pushgateway after manually triggering `prom-apt-upgradable.service`:

```
node_reboot_required{instance="cary",job="apt_upgradable"} 0        # flag file absent
node_reboot_required{instance="littlebox",job="apt_upgradable"} 1   # flag file present
```

Also confirmed on cary that the deployed script contains the new gauge and the installed timer unit has `OnBootSec=2min`.